### PR TITLE
Skip Authentication for /cars and /cars/id

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -1,4 +1,6 @@
 class CarsController < ApplicationController
+  skip_before_action :authenticate_user!, only: %I[index show]
+
   def index
     # Return all cars from DB
     @cars = Car.all

--- a/app/views/cars/show.html.erb
+++ b/app/views/cars/show.html.erb
@@ -19,7 +19,8 @@
           </li>
           <div class="btn-group" role="group">
             <%= link_to 'Book', new_car_booking_path(@car), class: 'btn btn-success' %>
-            <% if current_user.id == @car.user_id %>
+            
+            <% if user_signed_in? && current_user.id == @car.user_id %>
               <%= link_to 'Edit', edit_car_path(@car), class: 'btn btn-warning' %>
               <%= link_to 'Detete', car_path(@car), class: 'btn btn-danger', method: :delete, data: { confirm: 'Are you sure you want to delete this car!?' } %>
             <% end %>


### PR DESCRIPTION
For both user stories for a visitor to see All cars and Individual cars.
As soon as they attempt to book they need to log in, once logged in it will return to the booking page from them to continue.